### PR TITLE
Improve terminal cursor and selection contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "executive-theme" extension will be documented in this file.
 
+## [Unreleased]
+
+- Improve terminal usability:
+  - Increase terminal selection highlight contrast
+  - Increase terminal cursor contrast/visibility
+
 ## [0.0.1] - 2025-07-07
 
--   Initial release
+- Initial release

--- a/themes/Executive Theme-color-theme.json
+++ b/themes/Executive Theme-color-theme.json
@@ -793,7 +793,7 @@
             "name": "Attribute IDs",
             "scope": "entity.other.attribute-name.id",
             "settings": {
-                "fontStyle": "normal",
+                "fontStyle": "",
                 "foreground": "#2b9ed1"
             }
         },
@@ -801,7 +801,7 @@
             "name": "Attribute class",
             "scope": "entity.other.attribute-name.class.css",
             "settings": {
-                "fontStyle": "normal",
+                "fontStyle": "",
                 "foreground": "#dd8730"
             }
         },
@@ -1885,9 +1885,9 @@
         "badge.foreground": "#ffe6cc",
         "terminal.background": "#181e21",
         "terminal.foreground": "#dec1a3",
-        "terminal.selectionBackground": "#38636d2e",
-        "terminalCursor.background": "#1c6f73",
-        "terminalCursor.foreground": "#342910",
+        "terminal.selectionBackground": "#1c6f7366",
+        "terminalCursor.background": "#181e21",
+        "terminalCursor.foreground": "#1c6f73",
         "terminal.border": "#543529",
         "terminal.ansiBlack": "#000000",
         "terminal.ansiBlue": "#2e99c2",


### PR DESCRIPTION
Increase terminal cursor visibility (cyan line/underline; readable block) and stronger selection; documented in CHANGELOG.  (My eyes are old and can't clearly see what I'm highlighting in the terminal)